### PR TITLE
Revert "Bump express-rate-limit from 6.7.0 to 6.9.0"

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -21,7 +21,7 @@
         "dom-parser": "^0.1.6",
         "dotenv": "^16.3.1",
         "express": "^4.18.2",
-        "express-rate-limit": "^6.9.0",
+        "express-rate-limit": "^6.7.0",
         "http": "^0.0.1-security",
         "iconv-lite": "^0.6.3",
         "ini": "^4.1.1",
@@ -3975,11 +3975,11 @@
       }
     },
     "node_modules/express-rate-limit": {
-      "version": "6.9.0",
-      "resolved": "https://registry.npmjs.org/express-rate-limit/-/express-rate-limit-6.9.0.tgz",
-      "integrity": "sha512-AnISR3V8qy4gpKM62/TzYdoFO9NV84fBx0POXzTryHU/qGUJBWuVGd+JhbvtVmKBv37t8/afmqdnv16xWoQxag==",
+      "version": "6.7.0",
+      "resolved": "https://registry.npmjs.org/express-rate-limit/-/express-rate-limit-6.7.0.tgz",
+      "integrity": "sha512-vhwIdRoqcYB/72TK3tRZI+0ttS8Ytrk24GfmsxDXK9o9IhHNO5bXRiXQSExPQ4GbaE5tvIS7j1SGrxsuWs+sGA==",
       "engines": {
-        "node": ">= 14.0.0"
+        "node": ">= 12.9.0"
       },
       "peerDependencies": {
         "express": "^4 || ^5"

--- a/package.json
+++ b/package.json
@@ -23,7 +23,7 @@
     "dom-parser": "^0.1.6",
     "dotenv": "^16.3.1",
     "express": "^4.18.2",
-    "express-rate-limit": "^6.9.0",
+    "express-rate-limit": "^6.7.0",
     "http": "^0.0.1-security",
     "iconv-lite": "^0.6.3",
     "ini": "^4.1.1",


### PR DESCRIPTION
Reverts frontendnetwork/VeganCheck.me-API#47