### PR TITLE
fix: handle 404 errors gracefully in product API calls

### DIFF
--- a/OpenAPI.yaml
+++ b/OpenAPI.yaml
@@ -229,6 +229,8 @@ servers:
     description: Production server
   - url: https://api.staging.veganify.app
     description: Staging server
+  - url: http://localhost:8080
+    description: Local server
 components:
   schemas:
     BarcodeDto:

--- a/src/main.ts
+++ b/src/main.ts
@@ -7,7 +7,6 @@ import { Logger } from "nestjs-pino";
 
 import { AppModule } from "./app.module";
 
-
 async function bootstrap() {
   const app = await NestFactory.create(AppModule);
   const logger = app.get(Logger);
@@ -23,6 +22,7 @@ async function bootstrap() {
     .setLicense("MIT", "https://opensource.org/licenses/MIT")
     .addServer("https://api.veganify.app", "Production server")
     .addServer("https://api.staging.veganify.app", "Staging server")
+    .addServer("http://localhost:8080", "Local server")
     .build();
 
   const document = SwaggerModule.createDocument(app, options);

--- a/src/product/product.controller.ts
+++ b/src/product/product.controller.ts
@@ -1,4 +1,11 @@
-import { Controller, Param, Post, Res, Logger } from "@nestjs/common";
+import {
+  Controller,
+  Param,
+  Post,
+  Res,
+  Logger,
+  NotFoundException,
+} from "@nestjs/common";
 import { ApiResponse, ApiTags } from "@nestjs/swagger";
 import { Response } from "express";
 
@@ -41,11 +48,15 @@ export class ProductController {
       return res.status(200).json(result);
     } catch (error) {
       this.logger.error(error);
-      // eslint-disable-next-line @typescript-eslint/no-explicit-any
-      if ((error as any).status === 404)
+
+      // Handle NestJS exceptions
+      if (error instanceof NotFoundException) {
         return res
           .status(404)
           .json({ status: 404, error: "Product not found" });
+      }
+
+      // Handle other errors
       return res
         .status(500)
         .json({ status: 500, error: "Internal server error" });

--- a/src/product/product.service.ts
+++ b/src/product/product.service.ts
@@ -53,8 +53,8 @@ export class ProductService {
     }
 
     // Process OpenFoodFacts data
-    if (openFoodFactsResponse.data.status === 1) {
-      const product = openFoodFactsResponse.data.product;
+    if (openFoodFactsResponse.status === 1) {
+      const product = openFoodFactsResponse.product;
       apiname = "OpenFoodFacts";
       baseuri = "https://world.openfoodfacts.org";
       edituri = product.url;
@@ -101,7 +101,7 @@ export class ProductService {
       }
 
       if (product?.product?.brands) {
-        const dnt = petaResponse.data.PETA_DOES_NOT_TEST;
+        const dnt = petaResponse.PETA_DOES_NOT_TEST;
         const tester = dnt.toString().toLowerCase();
 
         if (tester.includes(product.product.brands.toLowerCase())) {
@@ -112,7 +112,7 @@ export class ProductService {
     } else {
       // Try OpenEANDB as fallback
       const openEanDbResponse = await this.fetchOpenEanDb(barcode);
-      const array = ini.parse(openEanDbResponse.data);
+      const array = ini.parse(openEanDbResponse);
 
       if (array.error === "0") {
         apiname = "Open EAN Database";
@@ -177,12 +177,22 @@ export class ProductService {
     return this.fetchWithCache(
       key,
       async () => {
-        const gradeResponse = await firstValueFrom(
-          this.httpService.get(
-            `https://grades.veganify.app/api/${barcode}.json`
-          )
-        );
-        return gradeResponse?.data;
+        try {
+          const gradeResponse = await firstValueFrom(
+            this.httpService.get(
+              `https://grades.veganify.app/api/${barcode}.json`
+            )
+          );
+          return gradeResponse?.data;
+        } catch (error) {
+          // If it's a 404, return "404" string as expected by the processing logic
+          const axiosError = error as { response?: { status?: number } };
+          if (axiosError.response?.status === 404) {
+            return "404";
+          }
+          // Re-throw other errors
+          throw error;
+        }
       },
       60 * 60 // Cache grades for 1 hour
     );
@@ -192,10 +202,22 @@ export class ProductService {
     const key = this.cacheService.generateOpenFoodFactsKey(barcode);
     return this.fetchWithCache(
       key,
-      () =>
-        axios.get(
-          `https://world.openfoodfacts.org/api/v0/product/${barcode}.json`
-        ),
+      async () => {
+        try {
+          const response = await axios.get(
+            `https://world.openfoodfacts.org/api/v0/product/${barcode}.json`
+          );
+          return response.data; // Extract only the data, not the entire response
+        } catch (error) {
+          // If it's a 404, return a proper response structure
+          const axiosError = error as { response?: { status?: number } };
+          if (axiosError.response?.status === 404) {
+            return { status: 0, product: null };
+          }
+          // Re-throw other errors
+          throw error;
+        }
+      },
       24 * 60 * 60 // Cache for 24 hours
     );
   }
@@ -204,7 +226,12 @@ export class ProductService {
     const key = this.cacheService.generatePetaKey();
     return this.fetchWithCache(
       key,
-      () => axios.get("https://api.veganify.app/v0/peta/crueltyfree"),
+      async () => {
+        const response = await axios.get(
+          "https://api.veganify.app/v0/peta/crueltyfree"
+        );
+        return response.data; // Extract only the data, not the entire response
+      },
       24 * 60 * 60 // Cache for 24 hours
     );
   }
@@ -213,10 +240,12 @@ export class ProductService {
     const key = this.cacheService.generateOpenEANDBKey(barcode);
     return this.fetchWithCache(
       key,
-      () =>
-        axios.get(
+      async () => {
+        const response = await axios.get(
           `https://opengtindb.org/?ean=${barcode}&cmd=query&queryid=${process.env.USER_ID_OEANDB}`
-        ),
+        );
+        return response.data; // Extract only the data, not the entire response
+      },
       7 * 24 * 60 * 60 // Cache for 7 days (less frequently updated)
     );
   }


### PR DESCRIPTION
## Summary by Sourcery

Handle 404 errors gracefully across all external product data fetchers, streamline HTTP response handling, and update error mapping and API documentation.

Bug Fixes:
- Gracefully return fallback values on 404 responses from external API calls in ProductService instead of propagating errors

Enhancements:
- Unwrap axios responses to return only response data in cached fetchers for OpenFoodFacts, PETA, OpenEANDB, and grades APIs
- Adjust property accesses to match simplified response shapes
- Add try-catch wrappers around external API calls to intercept 404s and fallback appropriately
- Enhance controller error handling by catching NotFoundException and returning a consistent 404 JSON response

Documentation:
- Include local server (http://localhost:8080) in OpenAPI spec and Swagger setup