### PR TITLE
hotfix: ? is not supported anymore

### DIFF
--- a/src/product/product.controller.ts
+++ b/src/product/product.controller.ts
@@ -16,7 +16,7 @@ export class ProductController {
   constructor(private readonly productService: ProductService) {}
   private readonly logger = new Logger(ProductController.name);
 
-  @Post(":barcode?")
+  @Post(":barcode")
   @ApiTags("Product")
   @ApiResponse({
     status: 200,


### PR DESCRIPTION
## Summary by Sourcery

Require a barcode path parameter for the product POST endpoint instead of allowing it to be optional.